### PR TITLE
Final polishing for KarlsenHashv2 mainnet

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,28 +9,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Build gnu-linux on ubuntu-18.04 and musl on ubuntu latest
-        # os: [ ubuntu-18.04, ubuntu-latest, windows-latest, macos-latest ]
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: Building, ${{ matrix.os }}
+        include:
+          - os: ubuntu-latest
+            TARGET: linux-gnu/amd64
+          - os: ubuntu-latest
+            TARGET: linux-gnu/aarch64
+          - os: ubuntu-latest
+            TARGET: linux-musl/amd64
+          - os: ubuntu-latest
+            TARGET: linux-musl/aarch64
+          - os: windows-latest
+            TARGET: windows-gnullvm/amd64
+          - os: windows-latest
+            TARGET: windows-msvc/amd64
+          - os: macos-latest
+            TARGET: macos/amd64
+          - os: macos-latest
+            TARGET: macos/aarch64
+    name: Building, ${{ matrix.TARGET }}
     steps:
       - name: Fix CRLF on Windows
         if: runner.os == 'Windows'
         run: git config --global core.autocrlf false
 
       - name: Checkout sources
-        uses: actions/checkout@v3
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -40,85 +49,195 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install zig on linux
+      - name: Install zig on Linux
         if: runner.os == 'Linux'
         uses: goto-bus-stop/setup-zig@v2 # needed for cargo-zigbuild
 
-      - name: Build on Linux
+      - name: Install protoc on Linux
         if: runner.os == 'Linux'
-        # We're using musl to make the binaries statically linked and portable
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
+
+      - name: Install protoc on macOS
+        if: runner.os == 'macOS'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
+
+      - name: Install msys2 on Windows
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: clang64
+          install: mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-protobuf zip
+
+      - name: Build on Linux for linux-gnu/amd64
+        if: matrix.TARGET == 'linux-gnu/amd64'
+        env:
+          TARGET_CC: x86_64-linux-gnu-gcc
+          TARGET_CXX: x86_64-linux-gnu-g++
+          RUSTFLAGS: -C linker=x86_64-linux-gnu-gcc
         run: |
-          cargo install cargo-zigbuild
-          cargo --verbose zigbuild --bin karlsend --bin simpa --bin rothschild --bin karlsen-wallet --release --target x86_64-unknown-linux-gnu.2.27 # Use an older glibc version
+          rustup target add x86_64-unknown-linux-gnu
+          cargo build --target x86_64-unknown-linux-gnu --bin karlsend --release
+          cargo build --target x86_64-unknown-linux-gnu --bin simpa --release
+          cargo build --target x86_64-unknown-linux-gnu --bin rothschild --release
+          cargo build --target x86_64-unknown-linux-gnu --bin karlsen-wallet --release
           mkdir bin || true
           cp target/x86_64-unknown-linux-gnu/release/karlsend bin/
           cp target/x86_64-unknown-linux-gnu/release/simpa bin/
           cp target/x86_64-unknown-linux-gnu/release/rothschild bin/
           cp target/x86_64-unknown-linux-gnu/release/karlsen-wallet bin/
           archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
-          asset_name="rusty-karlsen-${{ github.event.release.tag_name }}-linux-gnu-amd64.zip"
           zip -r "${archive}" ./bin/*
-          echo "archive=${archive}" >> $GITHUB_ENV
-          echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
-      - name: Build on Windows
-        if: runner.os == 'Windows'
-        shell: bash
+      - name: Build on Linux for linux-gnu/aarch64
+        if: matrix.TARGET == 'linux-gnu/aarch64'
+        env:
+          TARGET_CC: aarch64-linux-gnu-gcc
+          TARGET_CXX: aarch64-linux-gnu-g++
+          RUSTFLAGS: -C linker=aarch64-linux-gnu-gcc
         run: |
-          cargo build --bin karlsend --release
-          cargo build --bin simpa --release
-          cargo build --bin rothschild --release
-          cargo build --bin karlsen-wallet --release
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          rustup target add aarch64-unknown-linux-gnu
+          cargo build --target aarch64-unknown-linux-gnu --bin karlsend --release
+          cargo build --target aarch64-unknown-linux-gnu --bin simpa --release
+          cargo build --target aarch64-unknown-linux-gnu --bin rothschild --release
+          cargo build --target aarch64-unknown-linux-gnu --bin karlsen-wallet --release
           mkdir bin || true
-          cp target/release/karlsend.exe bin/
-          cp target/release/simpa.exe bin/
-          cp target/release/rothschild.exe bin/
-          cp target/release/karlsen-wallet.exe bin/
-          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-win64.zip"
-          asset_name="rusty-karlsen-${{ github.event.release.tag_name }}-win64.zip"
-          powershell "Compress-Archive bin/* \"${archive}\""
-          echo "archive=${archive}" >> $GITHUB_ENV
-          echo "asset_name=${asset_name}" >> $GITHUB_ENV
-
-      - name: Build on MacOS
-        if: runner.os == 'macOS'
-        run: |
-          cargo build --bin karlsend --release
-          cargo build --bin simpa --release
-          cargo build --bin rothschild --release
-          cargo build --bin karlsen-wallet --release
-          mkdir bin || true
-          cp target/release/karlsend bin/
-          cp target/release/simpa bin/
-          cp target/release/rothschild bin/
-          cp target/release/karlsen-wallet bin/
-          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-osx.zip"
-          asset_name="rusty-karlsen-${{ github.event.release.tag_name }}-osx.zip"
+          cp target/aarch64-unknown-linux-gnu/release/karlsend bin/
+          cp target/aarch64-unknown-linux-gnu/release/simpa bin/
+          cp target/aarch64-unknown-linux-gnu/release/rothschild bin/
+          cp target/aarch64-unknown-linux-gnu/release/karlsen-wallet bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-linux-gnu-aarch64.zip"
           zip -r "${archive}" ./bin/*
-          echo "archive=${archive}" >> $GITHUB_ENV
-          echo "asset_name=${asset_name}" >> $GITHUB_ENV
+
+      - name: Build on Linux for linux-musl/amd64
+        if: matrix.TARGET == 'linux-musl/amd64'
+
+        # We're using musl to make the binaries statically linked and portable.
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo install cargo-zigbuild
+          cargo --verbose zigbuild --bin karlsend --bin simpa --bin rothschild --bin karlsen-wallet --release --target x86_64-unknown-linux-musl
+          mkdir bin || true
+          cp target/x86_64-unknown-linux-musl/release/karlsend bin/
+          cp target/x86_64-unknown-linux-musl/release/simpa bin/
+          cp target/x86_64-unknown-linux-musl/release/rothschild bin/
+          cp target/x86_64-unknown-linux-musl/release/karlsen-wallet bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-linux-musl-amd64.zip"
+          zip -r "${archive}" ./bin/*
+
+      - name: Build on Linux for linux-musl/aarch64
+        if: matrix.TARGET == 'linux-musl/aarch64'
+
+        # We're using musl to make the binaries statically linked and portable.
+        env:
+          RUSTFLAGS: -C target-feature=-crt-static
+        run: |
+          rustup target add aarch64-unknown-linux-musl
+          cargo install cargo-zigbuild
+          cargo --verbose zigbuild --bin karlsend --bin simpa --bin rothschild --bin karlsen-wallet --release --target aarch64-unknown-linux-musl
+          mkdir bin || true
+          cp target/aarch64-unknown-linux-musl/release/karlsend bin/
+          cp target/aarch64-unknown-linux-musl/release/simpa bin/
+          cp target/aarch64-unknown-linux-musl/release/rothschild bin/
+          cp target/aarch64-unknown-linux-musl/release/karlsen-wallet bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-linux-musl-aarch64.zip"
+          zip -r "${archive}" ./bin/*
+
+      - name: Build on Windows for windows-gnullvm/amd64
+        if: matrix.TARGET == 'windows-gnullvm/amd64'
+
+        # We're using clang to link only the ucrt library statically.
+        env:
+          RUSTFLAGS: -L/clang64/lib -lstatic=c++
+        shell: msys2 {0}
+        run: |
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin" # manually override path to select proper msys2 build tools.
+          rustup target add x86_64-pc-windows-gnullvm
+          cargo build --target x86_64-pc-windows-gnullvm --bin karlsend --release
+          cargo build --target x86_64-pc-windows-gnullvm --bin simpa --release
+          cargo build --target x86_64-pc-windows-gnullvm --bin rothschild --release
+          cargo build --target x86_64-pc-windows-gnullvm --bin karlsen-wallet --release
+          mkdir bin || true
+          cp target/x86_64-pc-windows-gnullvm/release/karlsend.exe bin/
+          cp target/x86_64-pc-windows-gnullvm/release/simpa.exe bin/
+          cp target/x86_64-pc-windows-gnullvm/release/rothschild.exe bin/
+          cp target/x86_64-pc-windows-gnullvm/release/karlsen-wallet.exe bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-windows-gnullvm-amd64.zip"
+          zip -r "${archive}" ./bin/*
+
+      - name: Build on Windows for windows-msvc/amd64
+        if: matrix.TARGET == 'windows-msvc/amd64'
+        shell: msys2 {0}
+        run: |
+          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin" # manually override path to select proper msys2 build tools.
+          rustup target add x86_64-pc-windows-msvc
+          cargo build --target x86_64-pc-windows-msvc --bin karlsend --release
+          cargo build --target x86_64-pc-windows-msvc --bin simpa --release
+          cargo build --target x86_64-pc-windows-msvc --bin rothschild --release
+          cargo build --target x86_64-pc-windows-msvc --bin karlsen-wallet --release
+          mkdir bin || true
+          cp target/x86_64-pc-windows-msvc/release/karlsend.exe bin/
+          cp target/x86_64-pc-windows-msvc/release/simpa.exe bin/
+          cp target/x86_64-pc-windows-msvc/release/rothschild.exe bin/
+          cp target/x86_64-pc-windows-msvc/release/karlsen-wallet.exe bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-windows-msvc-amd64.zip"
+          zip -r "${archive}" ./bin/*
+
+      - name: Build on macOS for macos/amd64
+        if: matrix.TARGET == 'macos/amd64'
+        run: |
+          rustup target add x86_64-apple-darwin
+          cargo build --target x86_64-apple-darwin --bin karlsend --release
+          cargo build --target x86_64-apple-darwin --bin simpa --release
+          cargo build --target x86_64-apple-darwin --bin rothschild --release
+          cargo build --target x86_64-apple-darwin --bin karlsen-wallet --release
+          mkdir bin || true
+          cp target/x86_64-apple-darwin/release/karlsend bin/
+          cp target/x86_64-apple-darwin/release/simpa bin/
+          cp target/x86_64-apple-darwin/release/rothschild bin/
+          cp target/x86_64-apple-darwin/release/karlsen-wallet bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-macos-amd64.zip"
+          zip -r "${archive}" ./bin/*
+
+      - name: Build on macOS for macos/aarch64
+        if: matrix.TARGET == 'macos/aarch64'
+        run: |
+          rustup target add aarch64-apple-darwin
+          cargo build --target aarch64-apple-darwin --bin karlsend --release
+          cargo build --target aarch64-apple-darwin --bin simpa --release
+          cargo build --target aarch64-apple-darwin --bin rothschild --release
+          cargo build --target aarch64-apple-darwin --bin karlsen-wallet --release
+          mkdir bin || true
+          cp target/aarch64-apple-darwin/release/karlsend bin/
+          cp target/aarch64-apple-darwin/release/simpa bin/
+          cp target/aarch64-apple-darwin/release/rothschild bin/
+          cp target/aarch64-apple-darwin/release/karlsen-wallet bin/
+          archive="bin/rusty-karlsen-${{ github.event.release.tag_name }}-macos-aarch64.zip"
+          zip -r "${archive}" ./bin/*
 
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "./${{ env.archive }}"
-          asset_name: "${{ env.asset_name }}"
-          asset_content_type: application/zip
+          files: |
+            bin/*.zip
 
   build-wasm:
     runs-on: ubuntu-latest
     name: Building WASM32 SDK
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v3
+        uses: taiki-e/install-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tool: protoc
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -140,7 +259,8 @@ jobs:
           sudo update-alternatives --install /usr/bin/c++ c++ /usr/lib/llvm-15/bin/clang++ 0
 
       - name: Install gcc-multilib
-        # gcc-multilib allows clang to find gnu libraries properly
+
+        # gcc-multilib allows clang to find gnu libraries properly.
         run: sudo apt install -y gcc-multilib
 
       - name: Install stable toolchain
@@ -162,7 +282,7 @@ jobs:
         run: npm install --global typedoc typescript
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -174,21 +294,13 @@ jobs:
 
       - name: Build WASM32 SDK
         run: |
+          mkdir sdk || true
           cd wasm
           bash build-release
-          mv release/karlsen-wasm32-sdk.zip ../karlsen-wasm32-sdk-${{ github.event.release.tag_name }}.zip
-
-          archive="karlsen-wasm32-sdk-${{ github.event.release.tag_name }}.zip"
-          asset_name="karlsen-wasm32-sdk-${{ github.event.release.tag_name }}.zip"
-          echo "archive=${archive}" >> $GITHUB_ENV
-          echo "asset_name=${asset_name}" >> $GITHUB_ENV
+          mv release/karlsen-wasm32-sdk.zip ../sdk/karlsen-wasm32-sdk-${{ github.event.release.tag_name }}.zip
 
       - name: Upload WASM32 SDK
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "./${{ env.archive }}"
-          asset_name: "${{ env.asset_name }}"
-          asset_content_type: application/zip
+          files: |
+            sdk/*.zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.78.0"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Karlsen developers"]
 license = "ISC"
 repository = "https://github.com/karlsen-network/rusty-karlsen"
@@ -79,62 +79,62 @@ include = [
 ]
 
 [workspace.dependencies]
-# karlsen-testing-integration = { version = "0.1.0", path = "testing/integration" }
-karlsen-addresses = { version = "0.1.0", path = "crypto/addresses" }
-karlsen-addressmanager = { version = "0.1.0", path = "components/addressmanager" }
-karlsen-bip32 = { version = "0.1.0", path = "wallet/bip32" }
-karlsen-resolver = { version = "0.1.0", path = "rpr/wrpc/resolver" }
-karlsen-cli = { version = "0.1.0", path = "cli" }
-karlsen-connectionmanager = { version = "0.1.0", path = "components/connectionmanager" }
-karlsen-consensus = { version = "0.1.0", path = "consensus" }
-karlsen-consensus-core = { version = "0.1.0", path = "consensus/core" }
-karlsen-consensus-client = { version = "0.1.0", path = "consensus/client" }
-karlsen-consensus-notify = { version = "0.1.0", path = "consensus/notify" }
-karlsen-consensus-wasm = { version = "0.1.0", path = "consensus/wasm" }
-karlsen-consensusmanager = { version = "0.1.0", path = "components/consensusmanager" }
-karlsen-core = { version = "0.1.0", path = "core" }
-karlsen-daemon = { version = "0.1.0", path = "daemon" }
-karlsen-database = { version = "0.1.0", path = "database" }
-karlsen-grpc-client = { version = "0.1.0", path = "rpc/grpc/client" }
-karlsen-grpc-core = { version = "0.1.0", path = "rpc/grpc/core" }
-karlsen-grpc-server = { version = "0.1.0", path = "rpc/grpc/server" }
-karlsen-hashes = { version = "0.1.0", path = "crypto/hashes" }
-karlsen-index-core = { version = "0.1.0", path = "indexes/core" }
-karlsen-index-processor = { version = "0.1.0", path = "indexes/processor" }
-karlsen-math = { version = "0.1.0", path = "math" }
-karlsen-merkle = { version = "0.1.0", path = "crypto/merkle" }
-karlsen-metrics-core = { version = "0.1.0", path = "metrics/core" }
-karlsen-mining = { version = "0.1.0", path = "mining" }
-karlsen-mining-errors = { version = "0.1.0", path = "mining/errors" }
-karlsen-muhash = { version = "0.1.0", path = "crypto/muhash" }
-karlsen-notify = { version = "0.1.0", path = "notify" }
-karlsen-p2p-flows = { version = "0.1.0", path = "protocol/flows" }
-karlsen-p2p-lib = { version = "0.1.0", path = "protocol/p2p" }
-karlsen-perf-monitor = { version = "0.1.0", path = "metrics/perf_monitor" }
-karlsen-pow = { version = "0.1.0", path = "consensus/pow" }
-karlsen-rpc-core = { version = "0.1.0", path = "rpc/core" }
-karlsen-rpc-macros = { version = "0.1.0", path = "rpc/macros" }
-karlsen-rpc-service = { version = "0.1.0", path = "rpc/service" }
-karlsen-txscript = { version = "0.1.0", path = "crypto/txscript" }
-karlsen-txscript-errors = { version = "0.1.0", path = "crypto/txscript/errors" }
-karlsen-utils = { version = "0.1.0", path = "utils" }
-karlsen-utils-tower = { version = "0.1.0", path = "utils/tower" }
-karlsen-utxoindex = { version = "0.1.0", path = "indexes/utxoindex" }
-karlsen-wallet = { version = "0.1.0", path = "wallet/native" }
-karlsen-wallet-cli-wasm = { version = "0.1.0", path = "wallet/wasm" }
-karlsen-wallet-keys = { version = "0.1.0", path = "wallet/keys" }
-karlsen-wallet-core = { version = "0.1.0", path = "wallet/core" }
-karlsen-wallet-macros = { version = "0.1.0", path = "wallet/macros" }
-karlsen-wasm = { version = "0.1.0", path = "wasm" }
-karlsen-wasm-core = { version = "0.1.0", path = "wasm/core" }
-karlsen-wrpc-client = { version = "0.1.0", path = "rpc/wrpc/client" }
-karlsen-wrpc-core = { version = "0.1.0", path = "rpc/wrpc/core" }
-karlsen-wrpc-proxy = { version = "0.1.0", path = "rpc/wrpc/proxy" }
-karlsen-wrpc-server = { version = "0.1.0", path = "rpc/wrpc/server" }
-karlsen-wrpc-wasm = { version = "0.1.0", path = "rpc/wrpc/wasm" }
-karlsen-wrpc-example-subscriber = { version = "0.1.0", path = "rpc/wrpc/examples/subscriber" }
-karlsend = { version = "0.1.0", path = "karlsend" }
-karlsen-alloc = { version = "0.1.0", path = "utils/alloc" }
+# karlsen-testing-integration = { version = "2.0.0", path = "testing/integration" }
+karlsen-addresses = { version = "2.0.0", path = "crypto/addresses" }
+karlsen-addressmanager = { version = "2.0.0", path = "components/addressmanager" }
+karlsen-bip32 = { version = "2.0.0", path = "wallet/bip32" }
+karlsen-resolver = { version = "2.0.0", path = "rpr/wrpc/resolver" }
+karlsen-cli = { version = "2.0.0", path = "cli" }
+karlsen-connectionmanager = { version = "2.0.0", path = "components/connectionmanager" }
+karlsen-consensus = { version = "2.0.0", path = "consensus" }
+karlsen-consensus-core = { version = "2.0.0", path = "consensus/core" }
+karlsen-consensus-client = { version = "2.0.0", path = "consensus/client" }
+karlsen-consensus-notify = { version = "2.0.0", path = "consensus/notify" }
+karlsen-consensus-wasm = { version = "2.0.0", path = "consensus/wasm" }
+karlsen-consensusmanager = { version = "2.0.0", path = "components/consensusmanager" }
+karlsen-core = { version = "2.0.0", path = "core" }
+karlsen-daemon = { version = "2.0.0", path = "daemon" }
+karlsen-database = { version = "2.0.0", path = "database" }
+karlsen-grpc-client = { version = "2.0.0", path = "rpc/grpc/client" }
+karlsen-grpc-core = { version = "2.0.0", path = "rpc/grpc/core" }
+karlsen-grpc-server = { version = "2.0.0", path = "rpc/grpc/server" }
+karlsen-hashes = { version = "2.0.0", path = "crypto/hashes" }
+karlsen-index-core = { version = "2.0.0", path = "indexes/core" }
+karlsen-index-processor = { version = "2.0.0", path = "indexes/processor" }
+karlsen-math = { version = "2.0.0", path = "math" }
+karlsen-merkle = { version = "2.0.0", path = "crypto/merkle" }
+karlsen-metrics-core = { version = "2.0.0", path = "metrics/core" }
+karlsen-mining = { version = "2.0.0", path = "mining" }
+karlsen-mining-errors = { version = "2.0.0", path = "mining/errors" }
+karlsen-muhash = { version = "2.0.0", path = "crypto/muhash" }
+karlsen-notify = { version = "2.0.0", path = "notify" }
+karlsen-p2p-flows = { version = "2.0.0", path = "protocol/flows" }
+karlsen-p2p-lib = { version = "2.0.0", path = "protocol/p2p" }
+karlsen-perf-monitor = { version = "2.0.0", path = "metrics/perf_monitor" }
+karlsen-pow = { version = "2.0.0", path = "consensus/pow" }
+karlsen-rpc-core = { version = "2.0.0", path = "rpc/core" }
+karlsen-rpc-macros = { version = "2.0.0", path = "rpc/macros" }
+karlsen-rpc-service = { version = "2.0.0", path = "rpc/service" }
+karlsen-txscript = { version = "2.0.0", path = "crypto/txscript" }
+karlsen-txscript-errors = { version = "2.0.0", path = "crypto/txscript/errors" }
+karlsen-utils = { version = "2.0.0", path = "utils" }
+karlsen-utils-tower = { version = "2.0.0", path = "utils/tower" }
+karlsen-utxoindex = { version = "2.0.0", path = "indexes/utxoindex" }
+karlsen-wallet = { version = "2.0.0", path = "wallet/native" }
+karlsen-wallet-cli-wasm = { version = "2.0.0", path = "wallet/wasm" }
+karlsen-wallet-keys = { version = "2.0.0", path = "wallet/keys" }
+karlsen-wallet-core = { version = "2.0.0", path = "wallet/core" }
+karlsen-wallet-macros = { version = "2.0.0", path = "wallet/macros" }
+karlsen-wasm = { version = "2.0.0", path = "wasm" }
+karlsen-wasm-core = { version = "2.0.0", path = "wasm/core" }
+karlsen-wrpc-client = { version = "2.0.0", path = "rpc/wrpc/client" }
+karlsen-wrpc-core = { version = "2.0.0", path = "rpc/wrpc/core" }
+karlsen-wrpc-proxy = { version = "2.0.0", path = "rpc/wrpc/proxy" }
+karlsen-wrpc-server = { version = "2.0.0", path = "rpc/wrpc/server" }
+karlsen-wrpc-wasm = { version = "2.0.0", path = "rpc/wrpc/wasm" }
+karlsen-wrpc-example-subscriber = { version = "2.0.0", path = "rpc/wrpc/examples/subscriber" }
+karlsend = { version = "2.0.0", path = "karlsend" }
+karlsen-alloc = { version = "2.0.0", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/README.md
+++ b/README.md
@@ -1,253 +1,363 @@
+# Karlsen On Rust
 
-<h1>Karlsen On Rust</h1>
+[![Build Status](https://github.com/karlsen-network/rusty-karlsen/actions/workflows/ci.yaml/badge.svg)](https://github.com/karlsen-network/rusty-karlsen/actions/workflows/ci.yaml)
+[![GitHub release](https://img.shields.io/github/v/release/karlsen-network/rusty-karlsen.svg)](https://github.com/karlsen-network/rusty-karlsen/releases)
+[![GitHub license](https://img.shields.io/github/license/karlsen-network/rusty-karlsen.svg)](https://github.com/karlsen-network/rusty-karlsen/blob/main/LICENSE)
+[![GitHub downloads](https://img.shields.io/github/downloads/karlsen-network/rusty-karlsen/total.svg)](https://github.com/karlsen-network/rusty-karlsen/releases)
+[![Join the Karlsen Discord Server](https://img.shields.io/discord/1169939685280337930.svg?label=&logo=discord&logoColor=ffffff)](https://discord.gg/ZPZRvgMJDT)
 
-Welcome to the Rust-based implementation of the Karlsen full-node and its ancillary libraries. This Alpha release serves as a drop-in replacement to the established <a href="https://github.com/karlsen-network/karlsend">Golang node</a> (once the rust rewrite is completed), introducing developers to the possibilities of Rust in the Karlsen network's context.
+Welcome to the Rust-based implementation of the Karlsen full-node and
+its ancillary libraries. This production release serves as a drop-in
+replacement to the established [Golang node](https://github.com/karlsen-network/karlsend),
+introducing developers to the possibilities of Rust in the Karlsen
+network's context.
 
-We invite developers and blockchain enthusiasts to collaborate, test, and optimize our Rust implementation. Each line of code here is an opportunity to contribute to the open-source blockchain movement, shaping a platform designed for scalability and speed without compromising on decentralization.
+We invite developers and blockchain enthusiasts to collaborate, test,
+and optimize our Rust implementation. Each line of code here is an
+opportunity to contribute to the open-source blockchain movement,
+shaping a platform designed for scalability and speed without
+compromising on decentralization.
 
-Your feedback, contributions, and issue reports will be integral to evolving this codebase from its Alpha phase into a mature and reliable node in the Karlsen network.
+Your feedback, contributions, and issue reports will be integral to
+evolving this codebase from its Alpha phase into a mature and reliable
+node in the Karlsen network.
+
+## Overview
+
+Karlsen is a fork of [Kaspa](https://github.com/kaspanet/rusty-kaspa)
+introducing a GPU-centric fork as a solution to the dominance of ASIC
+mining farms, aiming to empower small-scale miners and enhance
+decentralization. We focus on bridging the gap between blockchain
+technology, decentralized finance and the real world of payment systems
+and traditional finance.
+
+With Kaspa, our approach is one of friendly cohabitation. We operate
+under the same protocol, enjoy similar advantages, and face
+unidentified issues. Any significant improvements that need to be made
+in the primary codebase will be shared back.
+
+## Small Scale Miners
+
+The Karlsen Network team believes in decentralization and small-scale
+miners. We will ensure long-term GPU-friendly mining.
+
+## Smart Contracts
+
+The Karlsen Network team is launching an R&D project to connect the
+Karlsen blockchain with other blockchain ecosystems using a smart
+contract layer based on the [Cosmos SDK](https://v1.cosmos.network/sdk).
+
+This initiative aims to enhance interoperability, efficiency, and
+innovation in the blockchain space. By leveraging the Cosmos SDK's
+advanced features, we'll facilitate seamless transactions across
+different networks, offering new opportunities for users and
+developers.
+
+### Cosmos Hub
+
+[Cosmos](https://cosmos.network/) is a highly attractive ecosystem due
+to its innovative approach to blockchain interoperability, scalability,
+and usability. By enabling different blockchains to seamlessly
+communicate and exchange value, Cosmos opens up vast opportunities for
+businesses and developers to build and deploy decentralized
+applications that can operate across multiple blockchain environments.
+This interoperability fosters a more connected and efficient digital
+economy, potentially driving adoption and usage across various sectors,
+including finance, supply chain, and beyond.
+
+By connecting to Cosmos, we will open the door of a web3 ecosystem
+connected to a complete network of other blockchain project, making
+Karlsen Network more competitive and adaptable in the rapidly evolving
+landscape of decentralized technologies.
+
+### Karlsen Sidechain
+
+The creation of the Karlsen [sidechain](https://github.com/john-light/sidechains)
+with fast transaction times, smart contract capabilities, and a dual
+coin model, designed to integrate seamlessly with the Cosmos ecosystem
+and utilize the Karlsen (KLS) across all interconnected platforms,
+signifies a strategic advancement in Karlsen Network.
+
+This sidechain will not only enable quick and efficient
+inter-blockchain transactions but also support complex decentralized
+applications through its smart contract functionality.
+
+The ability to use Karlsen (KLS) across the entire ecosystem will
+ensure a unified and streamlined user experience, promoting greater
+adoption and utility within the Cosmos network. This sidechain aims
+to enhance scalability, foster innovation, and provide a flexible and
+user-centric blockchain solution that meets the diverse needs of
+developers, users, and investors within the Cosmos ecosystem.
 
 ## Installation
-  <details>
-  <summary>Building on Linux</summary>
+
+### Building on Linux
   
-  1. Install general prerequisites
+1. Install general prerequisites
 
-      ```bash
-      sudo apt install curl git build-essential libssl-dev pkg-config 
-      ```
+   ```bash
+   sudo apt install curl git build-essential libssl-dev pkg-config
+   ```
 
-  2. Install Protobuf (required for gRPC)
+2. Install Protobuf (required for gRPC)
   
-      ```bash
-      sudo apt install protobuf-compiler libprotobuf-dev #Required for gRPC
-      ```
-  3. Install the clang toolchain (required for RocksDB and WASM secp256k1 builds)
+   ```bash
+   sudo apt install protobuf-compiler libprotobuf-dev #Required for gRPC
+   ```
 
-      ```bash
-      sudo apt-get install clang-format clang-tidy \
-      clang-tools clang clangd libc++-dev \
-      libc++1 libc++abi-dev libc++abi1 \
-      libclang-dev libclang1 liblldb-dev \
-      libllvm-ocaml-dev libomp-dev libomp5 \
-      lld lldb llvm-dev llvm-runtime \
-      llvm python3-clang
-      ```
-  3. Install the [rust toolchain](https://rustup.rs/)
+3. Install the clang toolchain (required for RocksDB and WASM secp256k1
+   builds)
+
+   ```bash
+   sudo apt-get install clang-format clang-tidy \
+   clang-tools clang clangd libc++-dev \
+   libc++1 libc++abi-dev libc++abi1 \
+   libclang-dev libclang1 liblldb-dev \
+   libllvm-ocaml-dev libomp-dev libomp5 \
+   lld lldb llvm-dev llvm-runtime \
+   llvm python3-clang
+   ```
+
+3. Install the [rust toolchain](https://rustup.rs/)
      
-     If you already have rust installed, update it by running: `rustup update` 
-  4. Install wasm-pack
-      ```bash
-      cargo install wasm-pack
-      ```
-  4. Install wasm32 target
-      ```bash
-      rustup target add wasm32-unknown-unknown
-      ```      
-  5. Clone the repo
-      ```bash
-      git clone https://github.com/karlsen-network/rusty-karlsen
-      cd rusty-karlsen
-      ```
-  </details>
+   If you already have rust installed, update it by running:
+   `rustup update`
 
+4. Install wasm-pack
 
+   ```bash
+   cargo install wasm-pack
+   ```
 
-  <details>  
-  <summary>Building on Windows</summary>
+4. Install wasm32 target
 
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
 
-  1. [Install Git for Windows](https://gitforwindows.org/) or an alternative Git distribution.
+5. Clone the repo
 
-  2. Install [Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-win64.zip) and add the `bin` directory to your `Path`
+   ```bash
+   git clone https://github.com/karlsen-network/rusty-karlsen
+   cd rusty-karlsen
+   ```
 
-  
+### Building on Windows
+
+1. [Install Git for Windows](https://gitforwindows.org/) or an alternative Git distribution.
+
+2. Install [Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases/download/v21.10/protoc-21.10-win64.zip) and add the `bin` directory to your `Path`
+
 3. Install [LLVM-15.0.6-win64.exe](https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/LLVM-15.0.6-win64.exe)
 
-    Add the `bin` directory of the LLVM installation (`C:\Program Files\LLVM\bin`) to PATH
+   Add the `bin` directory of the LLVM installation
+   (`C:\Program Files\LLVM\bin`) to PATH
     
-    set `LIBCLANG_PATH` environment variable to point to the `bin` directory as well
+   Set `LIBCLANG_PATH` environment variable to point to the `bin`
+   directory as well
 
-    **IMPORTANT:** Due to C++ dependency configuration issues, LLVM `AR` installation on Windows may not function correctly when switching between WASM and native C++ code compilation (native `RocksDB+secp256k1` vs WASM32 builds of `secp256k1`). Unfortunately, manually setting `AR` environment variable also confuses C++ build toolchain (it should not be set for native but should be set for WASM32 targets). Currently, the best way to address this, is as follows: after installing LLVM on Windows, go to the target `bin` installation directory and copy or rename `LLVM_AR.exe` to `AR.exe`.
+   **IMPORTANT:** Due to C++ dependency configuration issues, LLVM
+   `AR` installation on Windows may not function correctly when
+   switching between WASM and native C++ code compilation (native
+   `RocksDB+secp256k1` vs WASM32 builds of `secp256k1`). Unfortunately,
+   manually setting `AR` environment variable also confuses C++ build
+   toolchain (it should not be set for native but should be set for
+   WASM32 targets). Currently, the best way to address this, is as
+   follows: after installing LLVM on Windows, go to the target `bin`
+   installation directory and copy or rename `LLVM_AR.exe` to `AR.exe`.
   
-  4. Install the [rust toolchain](https://rustup.rs/)
+4. Install the [rust toolchain](https://rustup.rs/)
      
-     If you already have rust installed, update it by running: `rustup update` 
-  5. Install wasm-pack
-      ```bash
-      cargo install wasm-pack
-      ```
-  6. Install wasm32 target
-      ```bash
-      rustup target add wasm32-unknown-unknown
-      ```      
-  7. Clone the repo
-      ```bash
-      git clone https://github.com/karlsen-network/rusty-karlsen
-      cd rusty-karlsen
-      ```
- </details>      
+   If you already have rust installed, update it by running:
+   `rustup update`
 
+5. Install wasm-pack
 
-  <details>  
-  <summary>Building on Mac OS</summary>
+   ```bash
+   cargo install wasm-pack
+   ```
 
+6. Install wasm32 target
 
-  1. Install Protobuf (required for gRPC)
-      ```bash
-      brew install protobuf
-      ```
-  2. Install llvm. 
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
+
+7. Clone the repo
+
+   ```bash
+   git clone https://github.com/karlsen-network/rusty-karlsen
+   cd rusty-karlsen
+   ```
+
+### Building on Mac OS
+
+1. Install Protobuf (required for gRPC)
+
+   ```bash
+   brew install protobuf
+   ```
+
+2. Install llvm.
   
-      The default XCode installation of `llvm` does not support WASM build targets.
-To build WASM on MacOS you need to install `llvm` from homebrew (at the time of writing, the llvm version for MacOS is 16.0.1).
-      ```bash
-      brew install llvm
-      ```
+   The default XCode installation of `llvm` does not support WASM
+   build targets. To build WASM on MacOS you need to install `llvm`
+   from homebrew (at the time of writing, the llvm version for MacOS
+   is 16.0.1).
 
-      **NOTE:** Homebrew can use different keg installation locations depending on your configuration. For example:
-      - `/opt/homebrew/opt/llvm` -> `/opt/homebrew/Cellar/llvm/16.0.1`
-      - `/usr/local/Cellar/llvm/16.0.1`
+   ```bash
+   brew install llvm
+   ```
 
-      To determine the installation location you can use `brew list llvm` command and then modify the paths below accordingly:
-      ```bash
-      % brew list llvm
-      /usr/local/Cellar/llvm/16.0.1/bin/FileCheck
-      /usr/local/Cellar/llvm/16.0.1/bin/UnicodeNameMappingGenerator
-      ...
-      ```
-      If you have `/opt/homebrew/Cellar`, then you should be able to use `/opt/homebrew/opt/llvm`.
+   **NOTE:** Homebrew can use different keg installation locations
+   depending on your configuration. For example:
 
-      Add the following to your `~/.zshrc` file:
-      ```bash
-      export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
-      export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
-      export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
-      export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
-      ```
+   - `/opt/homebrew/opt/llvm` -> `/opt/homebrew/Cellar/llvm/16.0.1`
+   - `/usr/local/Cellar/llvm/16.0.1`
 
-      Reload the `~/.zshrc` file
-      ```bash
-      source ~/.zshrc
-      ```
-  3. Install the [rust toolchain](https://rustup.rs/)
+   To determine the installation location you can use `brew list llvm`
+   command and then modify the paths below accordingly:
+
+   ```bash
+   % brew list llvm
+   /usr/local/Cellar/llvm/16.0.1/bin/FileCheck
+   /usr/local/Cellar/llvm/16.0.1/bin/UnicodeNameMappingGenerator
+   ...
+   ```
+
+   If you have `/opt/homebrew/Cellar`, then you should be able to use
+   `/opt/homebrew/opt/llvm`.
+
+   Add the following to your `~/.zshrc` file:
+
+   ```bash
+   export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+   export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"
+   export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"
+   export AR=/opt/homebrew/opt/llvm/bin/llvm-ar
+   ```
+
+   Reload the `~/.zshrc` file
+
+   ```bash
+   source ~/.zshrc
+   ```
+
+3. Install the [rust toolchain](https://rustup.rs/)
      
-     If you already have rust installed, update it by running: `rustup update` 
-  4. Install wasm-pack
-      ```bash
-      cargo install wasm-pack
-      ```
-  4. Install wasm32 target
-      ```bash
-      rustup target add wasm32-unknown-unknown
-      ```      
-  5. Clone the repo
-      ```bash
-      git clone https://github.com/karlsen-network/rusty-karlsen
-      cd rusty-karlsen
-      ```
+   If you already have rust installed, update it by running:
+   `rustup update`
 
- </details>   
+4. Install wasm-pack
 
-  <details>
+   ```bash
+   cargo install wasm-pack
+   ```
 
-  <summary>Building WASM32 SDK</summary>
+4. Install wasm32 target
 
-  Rust WebAssembly (WASM) refers to the use of the Rust programming language to write code that can be compiled into WebAssembly, a binary instruction format that runs in web browsers and NodeJs. This allows for easy development using JavaScript and TypeScript programming languages while retaining the benefits of Rust.
+   ```bash
+   rustup target add wasm32-unknown-unknown
+   ```
 
-  WASM SDK components can be built from sources by running:
-    - `./build-release` - build a full release package (includes both release and debug builds for web and nodejs targets)
-    - `./build-docs` - build TypeScript documentation
-    - `./build-web` - release web build
-    - `./build-web-dev` - development web build
-    - `./build-nodejs` - release nodejs build
-    - `./build-nodejs-dev` - development nodejs build
+5. Clone the repo
 
-  IMPORTANT: do not use `dev` builds in production. They are significantly larger, slower and include debug symbols.
+   ```bash
+   git clone https://github.com/karlsen-network/rusty-karlsen
+   cd rusty-karlsen
+   ```
 
-### Requirements
+### Building WASM32 SDK
 
-  - NodeJs (v20+): https://nodejs.org/en
-  - TypeDoc: https://typedoc.org/
+Rust WebAssembly (WASM) refers to the use of the Rust programming
+language to write code that can be compiled into WebAssembly, a binary
+instruction format that runs in web browsers and NodeJs. This allows
+for easy development using JavaScript and TypeScript programming
+languages while retaining the benefits of Rust.
 
-### Builds & documentation
+WASM SDK components can be built from sources by running:
 
-  - Release builds: https://github.com/karlsen-network/rusty-karlsen/releases
-  - Developer builds: https://kaspa.aspectron.org/nightly/downloads/
-  - Developer TypeScript documentation: https://kaspa.aspectron.org/docs/
+- `./build-release` - build a full release package (includes both
+  release and debug builds for web and nodejs targets)
+- `./build-docs` - build TypeScript documentation
+- `./build-web` - release web build
+- `./build-web-dev` - development web build
+- `./build-nodejs` - release nodejs build
+- `./build-nodejs-dev` - development nodejs build
 
-  </details>
-<details>
+**IMPORTANT:** do not use `dev` builds in production. They are
+significantly larger, slower and include debug symbols.
 
-<summary>
-Karlsen CLI + Wallet
-</summary>
-`karlsen-cli` crate provides cli-driven RPC interface to the node and a
-terminal interface to the Rusty Karlsen Wallet runtime. These wallets are
-compatible with WASM SDK Wallet API and Karlsen NG projects.
+#### Requirements
 
+- NodeJs (v20+): https://nodejs.org/en
+- TypeDoc: https://typedoc.org/
+
+#### Builds & documentation
+
+- Release builds: https://github.com/karlsen-network/rusty-karlsen/releases
+- Developer TypeScript documentation is available from [Kaspa](https://kaspa.aspectron.org/docs/)
+
+## Karlsen CLI + Wallet
+
+`karlsen-cli` crate provides cli-driven RPC interface to the node and
+a terminal interface to the Rusty Karlsen Wallet runtime. These wallets
+are compatible with WASM SDK Wallet API and Karlsen NG projects.
 
 ```bash
 cd cli
 cargo run --release
 ```
 
-</details>
+## Local Web Wallet
 
-
-
-<details>
-
-<summary>
-Local Web Wallet
-</summary>
-
-Run an http server inside of `wallet/wasm/web` folder. If you don't have once, you can use the following:
+Run an http server inside of `wallet/wasm/web` folder. If you don't
+have once, you can use the following:
 
 ```bash
 cd wallet/wasm/web
 cargo install basic-http-server
 basic-http-server
 ```
-The *basic-http-server* will serve on port 4000 by default, so open your web browser and load http://localhost:4000
+
+The *basic-http-server* will serve on port 4000 by default, so open
+your web browser and load http://localhost:4000
 
 The framework is compatible with all major desktop and mobile browsers.
 
-
-</details>
-
-
 ## Running the node
 
-  **Start a mainnet node**
+**Start a mainnet node**
 
-  ```bash
-  cargo run --release --bin karlsend
-  ```
-  **Start a testnet node**
+```bash
+cargo run --release --bin karlsend
+```
 
-  ```bash
+**Start a testnet node**
+
+```bash
 cargo run --release --bin karlsend -- --testnet
-  ```
-
-<details>
-
-  <summary>
+```
 Using a configuration file
-  </summary>
 
-  ```bash
+```bash
 cargo run --release --bin karlsend -- --configfile /path/to/configfile.toml
 # or
 cargo run --release --bin karlsend -- -C /path/to/configfile.toml
-  ```
-  - The config file should be a list of \<CLI argument\> = \<value\> separated by newlines. 
-  - Whitespace around the `=` is fine, `arg=value` and `arg = value` are both parsed correctly.
-  - Values with special characters like `.` or `=` will require quoting the value i.e \<CLI argument\> = "\<value\>".
-  - Arguments with multiple values should be surrounded with brackets like `addpeer = ["10.0.0.1", "1.2.3.4"]`.
+```
 
-  For example:
-  ```
+- The config file should be a list of \<CLI argument\> = \<value\>
+  separated by newlines.
+- Whitespace around the `=` is fine, `arg=value` and `arg = value`
+  are both parsed correctly.
+- Values with special characters like `.` or `=` will require quoting
+  the value i.e \<CLI argument\> = "\<value\>".
+- Arguments with multiple values should be surrounded with brackets
+  like `addpeer = ["10.0.0.1", "1.2.3.4"]`.
+
+For example:
+
+```
 testnet = true
 utxoindex = false
 disable-upnp = true
@@ -255,127 +365,110 @@ perf-metrics = true
 appdir = "some-dir"
 netsuffix = 11
 addpeer = ["10.0.0.1", "1.2.3.4"]
-  ```
- Pass the `--help` flag to view all possible arguments
+```
 
-  ```bash
+Pass the `--help` flag to view all possible arguments
+
+```bash
 cargo run --release --bin karlsend -- --help
-  ```
-</details>
+```
 
-<details>
+## wRPC
 
-  <summary>
-wRPC
-  </summary>
+wRPC subsystem is disabled by default in `karlsend` and can be enabled
+via:
 
-  wRPC subsystem is disabled by default in `karlsend` and can be enabled via:
+JSON protocol:
 
+```bash
+--rpclisten-json = <interface:port>
+```
 
-  JSON protocol:
-  ```bash
-  --rpclisten-json = <interface:port>
-  ```
+Borsh protocol:
 
-  Borsh protocol:
-  ```bash
-  --rpclisten-borsh = <interface:port>
-  ```
+```bash
+--rpclisten-borsh = <interface:port>
+```
 
-  **Sidenote:**
+### Sidenote
 
-  Rusty Karlsen integrates an optional wRPC
-  subsystem. wRPC is a high-performance, platform-neutral, Rust-centric, WebSocket-framed RPC 
-  implementation that can use [Borsh](https://borsh.io/) and JSON protocol encoding.
+Rusty Karlsen integrates an optional wRPC subsystem. wRPC is a
+high-performance, platform-neutral, Rust-centric, WebSocket-framed
+RPC implementation that can use [Borsh](https://borsh.io/) and JSON
+protocol encoding.
 
-  JSON protocol messaging 
-  is similar to JSON-RPC 1.0, but differs from the specification due to server-side 
-  notifications.
+JSON protocol messaging is similar to JSON-RPC 1.0, but differs from
+the specification due to server-side notifications.
 
-  [Borsh](https://borsh.io/) encoding is meant for inter-process communication. When using [Borsh](https://borsh.io/)
-  both client and server should be built from the same codebase.  
+[Borsh](https://borsh.io/) encoding is meant for inter-process
+communication. When using [Borsh](https://borsh.io/) both client and
+server should be built from the same codebase.
 
-  JSON protocol is based on 
-  Karlsen data structures and is data-structure-version agnostic. You can connect to the
-  JSON endpoint using any WebSocket library. Built-in RPC clients for JavaScript and
-  TypeScript capable of running in web browsers and Node.js are available as a part of
-  the Karlsen WASM framework.
+JSON protocol is based on Karlsen data structures and is
+data-structure-version agnostic. You can connect to the JSON endpoint
+using any WebSocket library. Built-in RPC clients for JavaScript and
+TypeScript capable of running in web browsers and Node.js are
+available as a part of the Karlsen WASM framework.
 
-  **wRPC to gRPC Proxy is deprecated and no longer supported.**
+**wRPC to gRPC Proxy is deprecated and no longer supported.**
 
-</details>
+## Mining
 
-
-
-<details>
-
-<summary>
-Mining
-</summary>
-
-Mining is currently supported only on testnet, so once you've setup a test node, follow these instructions.
+Mining is currently supported only on testnet, so once you've setup a
+test node, follow these instructions.
 
 1. Download and unzip the latest binaries bundle of [karlsen-network/karlsend](https://github.com/karlsen-network/karlsend/releases).
 
 2. In a separate terminal run the karlsen-network/karlsend miner:
 
-    ```
-    karlsenminer --testnet --miningaddr karlsentest:qrcqat6l9zcjsu7swnaztqzrv0s7hu04skpaezxk43y4etj8ncwfk308jlcew
-    ```
+   ```
+   karlsenminer --testnet --miningaddr karlsentest:qrcqat6l9zcjsu7swnaztqzrv0s7hu04skpaezxk43y4etj8ncwfk308jlcew
+   ```
 
-    This will create and feed a DAG with the miner getting block templates from the node and submitting them back when mined. The node processes and stores the blocks while applying all currently implemented logic. Execution can be stopped and resumed, the data is persisted in a database.
-
-    You can replace the above mining address with your own address by creating one as described [here](https://github.com/karlsen-network/docs/blob/main/Getting%20Started/Full%20Node%20Installation.md#creating-a-wallet-optional). 
-
-</details>
-
+This will create and feed a DAG with the miner getting block templates
+from the node and submitting them back when mined. The node processes
+and stores the blocks while applying all currently implemented logic.
+Execution can be stopped and resumed, the data is persisted in a
+database. You can replace the above mining address with your own
+address.
 
 ## Benchmarking & Testing
 
+### Simulation framework (Simpa)
 
-<details> 
+Logging in `karlsend` and `simpa` can be [filtered](https://docs.rs/env_logger/0.10.0/env_logger/#filtering-results)
+by either:
 
-<summary>Simulation framework (Simpa)</summary>
-
-Logging in `karlsend` and `simpa` can be [filtered](https://docs.rs/env_logger/0.10.0/env_logger/#filtering-results) by either:
-
-The current codebase supports a full in-process network simulation, building an actual DAG over virtual time with virtual delay and benchmarking validation time (following the simulation generation). 
-
+The current codebase supports a full in-process network simulation,
+building an actual DAG over virtual time with virtual delay and
+benchmarking validation time (following the simulation generation).
 To see the available commands
+
 ```bash 
 cargo run --release --bin simpa -- --help
-``` 
+```
 
-The following command will run a simulation to produce 1000 blocks with communication delay of 2 seconds and 8 BPS (blocks per second) while attempting to fill each block with up to 200 transactions.   
+The following command will run a simulation to produce 1000 blocks
+with communication delay of 2 seconds and 8 BPS (blocks per second)
+while attempting to fill each block with up to 200 transactions.
 
 ```bash
 cargo run --release --bin simpa -- -t=200 -d=2 -b=8 -n=1000
 ```
 
-</details>
+### Heap Profiling
 
-
-
-
-<details> 
-
-<summary>Heap Profiling</summary>
-
-Heap-profiling in `karlsend` and `simpa` can be done by enabling `heap` feature and profile using the `--features` argument
+Heap-profiling in `karlsend` and `simpa` can be done by enabling
+`heap` feature and profile using the `--features` argument.
 
 ```bash
 cargo run --bin karlsend --profile heap --features=heap
 ```
 
-It will produce `{bin-name}-heap.json` file in the root of the workdir, that can be inspected by the [dhat-viewer](https://github.com/unofficial-mirror/valgrind/tree/master/dhat)
+It will produce `{bin-name}-heap.json` file in the root of the workdir,
+that can be inspected by the [dhat-viewer](https://github.com/unofficial-mirror/valgrind/tree/master/dhat)
 
-</details>
-
-
-<details> 
-
-<summary>Tests</summary>
-
+### Tests
 
 **Run unit and most integration tests**
 
@@ -385,8 +478,6 @@ cargo test --release
 // or install nextest and run
 ```
 
-
-
 **Using nextest**
 
 ```bash
@@ -394,37 +485,23 @@ cd rusty-karlsen
 cargo nextest run --release
 ```
 
-
-
-</details>
-
-
-<details> 
-
-<summary>Benchmarks</summary>
+### Benchmarks
 
 ```bash
 cd rusty-karlsen
 cargo bench
 ```
 
-</details>
+### Logging
 
-<details> 
-
-<summary>Logging</summary>
-
-Logging in `karlsend` and `simpa` can be [filtered](https://docs.rs/env_logger/0.10.0/env_logger/#filtering-results) by either:
+Logging in `karlsend` and `simpa` can be [filtered](https://docs.rs/env_logger/0.10.0/env_logger/#filtering-results)
+by either:
 
 1. Defining the environment variable `RUST_LOG`
 2. Adding the --loglevel argument like in the following example:
 
-    ```
-    (cargo run --bin karlsend -- --loglevel info,karlsen_rpc_core=trace,karlsen_grpc_core=trace,consensus=trace,karlsen_core=trace) 2>&1 | tee ~/rusty-karlsen.log
-    ```
-    In this command we set the `loglevel` to `INFO`.
+   ```
+   (cargo run --bin karlsend -- --loglevel info,karlsen_rpc_core=trace,karlsen_grpc_core=trace,consensus=trace,karlsen_core=trace) 2>&1 | tee ~/rusty-karlsen.log
+   ```
 
-</details>
-
-
-
+   In this command we set the `loglevel` to `INFO`.

--- a/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
+++ b/consensus/src/pipeline/header_processor/pre_ghostdag_validation.rs
@@ -45,7 +45,9 @@ impl HeaderProcessor {
                 header.version,
                 constants::BLOCK_VERSION_KHASHV2,
             ));
-        } else if header.daa_score < hf_daa_score && header.version != constants::BLOCK_VERSION_KHASHV1 {
+        } else if header.daa_score < hf_daa_score
+            && header.version != constants::BLOCK_VERSION_KHASHV1
+        {
             return Err(RuleError::WrongBlockVersion(
                 header.version,
                 constants::BLOCK_VERSION_KHASHV1,

--- a/karlsend/src/daemon.rs
+++ b/karlsend/src/daemon.rs
@@ -415,7 +415,7 @@ do you confirm? (answer y/n or pass --yes to the Karlsend command line to confir
 
     let grpc_server_addr = args
         .rpclisten
-        .unwrap_or(ContextualNetAddress::loopback())
+        .unwrap_or(ContextualNetAddress::unspecified())
         .normalize(config.default_rpc_port());
 
     let core = Arc::new(Core::new());

--- a/rpc/wrpc/server/Cargo.toml
+++ b/rpc/wrpc/server/Cargo.toml
@@ -34,7 +34,7 @@ workflow-core.workspace = true
 workflow-log.workspace = true
 workflow-rpc.workspace = true
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.'cfg(unix)'.dependencies]
 # Adding explicitely the openssl dependency here is needed for a successful build with zigbuild
 # as used in the release deployment in GitHub CI
 # see: https://github.com/rust-cross/cargo-zigbuild/issues/127

--- a/rpc/wrpc/server/src/address.rs
+++ b/rpc/wrpc/server/src/address.rs
@@ -33,7 +33,17 @@ impl WrpcNetAddress {
                 };
                 format!("0.0.0.0:{port}").parse().unwrap()
             }
-            WrpcNetAddress::Custom(address) => *address,
+            WrpcNetAddress::Custom(address) => {
+                if address.port_not_specified() {
+                    let port = match encoding {
+                        WrpcEncoding::Borsh => network_type.default_borsh_rpc_port(),
+                        WrpcEncoding::SerdeJson => network_type.default_json_rpc_port(),
+                    };
+                    address.with_port(port)
+                } else {
+                    *address
+                }
+            }
         }
     }
 }
@@ -65,5 +75,39 @@ impl TryFrom<String> for WrpcNetAddress {
 
     fn try_from(s: String) -> Result<Self, Self::Error> {
         WrpcNetAddress::from_str(&s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use karlsen_utils::networking::IpAddress;
+
+    #[test]
+    fn test_wrpc_net_address_from_str() {
+        // Addresses
+        let port: u16 = 42110;
+        let addr = format!("1.2.3.4:{port}").parse::<WrpcNetAddress>().unwrap();
+        let addr_without_port = "1.2.3.4".parse::<WrpcNetAddress>().unwrap();
+        let ip_addr = "1.2.3.4".parse::<IpAddress>().unwrap();
+        // Test
+        for schema in WrpcEncoding::iter() {
+            for network in NetworkType::iter() {
+                let expected_port = match schema {
+                    WrpcEncoding::Borsh => Some(network.default_borsh_rpc_port()),
+                    WrpcEncoding::SerdeJson => Some(network.default_json_rpc_port()),
+                };
+                // Custom address with port
+                assert_eq!(
+                    addr.to_address(&network, schema),
+                    ContextualNetAddress::new(ip_addr, Some(port))
+                );
+                // Custom address without port
+                assert_eq!(
+                    addr_without_port.to_address(&network, schema),
+                    ContextualNetAddress::new(ip_addr, expected_port)
+                )
+            }
+        }
     }
 }

--- a/utils/src/networking.rs
+++ b/utils/src/networking.rs
@@ -325,7 +325,7 @@ pub struct ContextualNetAddress {
 }
 
 impl ContextualNetAddress {
-    fn new(ip: IpAddress, port: Option<u16>) -> Self {
+    pub fn new(ip: IpAddress, port: Option<u16>) -> Self {
         Self { ip, port }
     }
 
@@ -344,6 +344,17 @@ impl ContextualNetAddress {
         Self {
             ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)).into(),
             port: None,
+        }
+    }
+
+    pub fn port_not_specified(&self) -> bool {
+        self.port.is_none()
+    }
+
+    pub fn with_port(&self, port: u16) -> Self {
+        Self {
+            ip: self.ip,
+            port: Some(port),
         }
     }
 }


### PR DESCRIPTION
* Format fixes to make lint check happy.
* Version bump to `v2.0.0` for `KarlsenHashv2` in `mainnet`.
* Align RPC listener with current Golang behavior, listen on `0.0.0.0` instead of `127.0.0.1`
* Support IP only for `--rpclisten-borsh` and `--rpclisten-json`
* Fixed GitHub action warnings and add `aarch64` to the build targets