### PR TITLE
renamed `KDX` to `Karlsen Desktop` and update to `guide.txt`

### DIFF
--- a/cli/src/modules/account.rs
+++ b/cli/src/modules/account.rs
@@ -80,14 +80,14 @@ impl Account {
                     tprintln!(ctx, "");
                     ctx.term().help(
                         &[
-                            ("account import legacy-data", "Import KDX keydata file or karlsen-network web wallet data on the same domain"),
+                            ("account import legacy-data", "Import Karlsen-Desktop keydata file or Web Wallet data on the same domain"),
                             (
                                 "account import mnemonic bip32",
-                                "Import Bip32 (12 or 24 word mnemonics used by karlsenwallet, kaspium, onekey, tangem etc.)",
+                                "Import Bip32 (12 or 24 word mnemonics used by karlsenwallet or karlsen-mobile)",
                             ),
                             (
                                 "account import mnemonic legacy",
-                                "Import accounts 12 word mnemonic used by legacy applications (KDX and karlsen-network web wallet)",
+                                "Import accounts 12 word mnemonic used by legacy applications (Karlsen-Desktop and Web Wallet)",
                             ),
                             (
                                 "account import mnemonic multisig [additional keys]",
@@ -160,7 +160,7 @@ impl Account {
                         } else if application_runtime::is_web() {
                             return Err("'karlsen-network' web wallet storage not found at this domain name".into());
                         } else {
-                            return Err("KDX keydata file not found".into());
+                            return Err("Karlsen-Desktop keydata file not found".into());
                         }
                     }
                     "mnemonic" => {
@@ -170,7 +170,7 @@ impl Account {
                                 "usage: 'account import mnemonic <bip32|legacy|multisig>'"
                             );
                             tprintln!(ctx, "please specify the mnemonic type");
-                            tprintln!(ctx, "please use 'legacy' for 12-word KDX and karlsen-network web wallet mnemonics\r\n");
+                            tprintln!(ctx, "please use 'legacy' for 12-word Karlsen-Desktop and Web Wallet mnemonics\r\n");
                             return Ok(());
                         }
 
@@ -251,7 +251,7 @@ impl Account {
                 (
                     "import <import-type> [<key-type> [extra keys]]",
                     "Import accounts from a private key using 24 or 12 word mnemonic or legacy data \
-                (KDX and karlsen-network web wallet). Use 'account import' for additional help.",
+                (Karlsen-Desktop and Web Wallet). Use 'account import' for additional help.",
                 ),
                 ("name <name>", "Name or rename the selected account (use 'remove' to remove the name"),
                 ("scan [<derivations>] or scan [<start>] [<derivations>]", "Scan extended address derivation chain (legacy accounts)"),

--- a/cli/src/modules/guide.txt
+++ b/cli/src/modules/guide.txt
@@ -1,89 +1,61 @@
-Please note - this is an alpha version of the softeware, not all features are currently functional.
+Please note - this is an alpha version of the software, and not all features are currently functional.
 
-If using a dekstop or a web version of this software, you can use Ctrl+'+' or Ctrl+'-' (Command on MacOS) to
-change the terminal font size.
+If you are using the desktop or web version of this software, you can adjust the terminal font size with Ctrl+'+' or Ctrl+'-' (use Command on MacOS).
 
-If using a desktop version, you can use Ctrl+M (Command on MacOS) to bring up metrics.
+For the desktop version, you can press Ctrl+M (Command on MacOS) to bring up metrics.
 
-Type `help` to see the complete list of commands. `exit` to exit this application.
-On Windows you can use `Alt+F4` and on MacOS `Command+Q` to exit.
+Type `help` to view the full list of commands. To exit the application, type `exit`. On Windows, you can also use `Alt+F4`, and on MacOS, use `Command+Q` to exit.
 
 ---
 
-Before you start, you must configure the default network setting.  There are currently
-3 networks available.  `mainnet`, `testnet-1` and `testnet-11`.  While this software
-is in alpha stage, you should not use it on the mainnet.  If you wish to experiment,
-you should select `testnet-1` by entering `network testnet-1`
+Before starting, you need to configure the default network setting. Currently, three networks are available: `mainnet`, `testnet-1`, and `testnet-11`. While this software is in the alpha stage, you should avoid using it on the mainnet. For experimentation, select `testnet-1` by entering `network testnet-1`.
 
-The `server` command configures the target server.  You can connect to any Rusty Karlsen
-node that has User RPC enabled with `--rpclisten-borsh=public`. If you are running the node
-from within KOS, it is locked to listen to a local IP address.
+The `server` command configures the target server. You can connect to any Rusty Karlsen node with User RPC enabled using `--rpclisten-borsh=public`. If running the node within KOS, it is restricted to listen to a local IP address.
 
-Both network and server values are stored in the application settings and are 
-used when running a local node or connecting to a remote node.
+Both the network and server settings are stored in the application and are used when running a local node or connecting to a remote one.
 
 ---
 
-You can use `node start` to start the node.  Type `node` to see an overview of commands.
-`node mute` toggles node log output (you can also use `node logs`).  `node select` allows 
-you to choose between locally installed flavors (if running in the development environment).
-You can also specify an absolute path by typing `node select <path to rusty karlsen binary>`.
+Use `node start` to start the node. Type `node` to view an overview of commands. The `node mute` command toggles node log output (alternatively, you can use `node logs`). The `node select` command allows you to choose between locally installed versions if running in a development environment. You can also specify an absolute path by typing `node select <path to rusty karlsen binary>`.
 
-For developers: `node select` scans 'target' folder for the debug and release builds
-so you can switch between builds at runtime using the `node select` command.
+For developers, the `node select` command scans the 'target' folder for debug and release builds, allowing you to switch between builds at runtime.
 
-Once you node is running, you can connect to it using the `connect` command.
+Once your node is running, connect to it using the `connect` command.
 
-When starting the node and the `server` setting is configured to your local host, 
-the `connect` action will occure automatically.
+If the `server` setting is configured to your local host when starting the node, the `connect` action will occur automatically.
 
-`wallet create [<name>]` Use theis command to create a local wallet. The <name> argument 
-is optional (the default wallet name is "karlsen") and allows you to create multiple 
-named wallets.  Only one wallet can be opened at a time. Keep in mind that a wallet can have multiple
-accounts, as such you only need one wallet, unless, for example, you want to separate wallets for 
-personal and business needs (but you can also create isolated accounts within a wallet).
+`wallet create [<name>]` - Use this command to create a local wallet. The `<name>` argument is optional (the default wallet name is "karlsen"), allowing you to create multiple named wallets. Only one wallet can be open at a time. Remember, a wallet can have multiple accounts, so you may only need one wallet unless you want to separate wallets for personal and business use (though you can also create isolated accounts within a wallet).
 
-Make sure to record your mnemonic, even if working with a testnet, not to loose your
-testnet KLS.
+Be sure to record your mnemonic, even when working with a testnet, to avoid losing your testnet KLS.
 
-`open <name>` - opens the wallet (the wallet is open automatically after creation).
+`open <name>` - Opens the wallet (the wallet is opened automatically after creation).
 
 `list` - Lists all wallet accounts and their balances.
 
-`select <account-name>` - Selects an active account. The <account-name> can be the first few letters of the name or id of the account.
+`select <account-name>` - Selects an active account. The `<account-name>` can be the first few letters of the account name or ID.
 
-`account create bip32 [<name>]` - Allows you to create additional HD wallet accounts linked to the default private key of your wallet.
+`account create bip32 [<name>]` - Creates additional HD wallet accounts linked to the wallet's default private key.
 
-`address` - shows your selected account address
+`address` - Displays the address of the selected account.
 
-Note - you can click on the address to copy it to the clipboard.  (When on mainnet, Ctrl+Click on addresses, transactions and 
-block hashes will open a new browser window with an explorer.)
+Note - you can click on the address to copy it to the clipboard. When on the mainnet, Ctrl+Clicking on addresses, transactions, and block hashes will open a new browser window with an explorer.
 
-Before you transact: `mute` option (enabled by default) toggles mute on/off. Mute enables terminal
-output of internal framework events.  Rust and JavaScript/TypeScript applications integrating with this platform 
-are meant to update their state by monitoring event notifications. Mute allows you to see these events in
-the terminal.  When mute is off, all events are displayed in the terminal.  When mute is on, you can use 'track'
-command to enable specific event notification.
+Before transacting: The `mute` option (enabled by default) toggles mute on/off. Mute controls terminal output of internal framework events. Rust and JavaScript/TypeScript applications integrating with this platform update their state by monitoring event notifications. Mute allows you to see these events in the terminal. When mute is off, all events are displayed. When mute is on, use the `track` command to enable specific event notifications.
 
-`transfer <account-name> <amount>` - Transfers from the active to a different account. For example 'transfer p 1' will transfer 1 KLS from
-the selected account to an account named 'pete' (starts with a 'p' letter)
+`transfer <account-name> <amount>` - Transfers funds from the active account to a different account. For example, 'transfer p 1' transfers 1 KLS from the selected account to an account starting with 'p'.
 
-`send <address> <amount>` - Send funds to a destination address .
+`send <address> <amount>` - Sends funds to a specified address.
 
-`estimate <amount>` - Provides a fee and UTXO consumption estimate for a transaction of a given amount.
+`estimate <amount>` - Provides a fee and UTXO consumption estimate for a transaction of a specified amount.
 
-`sweep` - Sweeps account UTXOs to reduce the UTXO size.
+`sweep` - Sweeps account UTXOs to reduce their size.
 
-`history list` - Shows previous account transactions.
+`history list` - Displays a list of previous account transactions.
 
-`history details` - Show previous account transactions with extended information.
+`history details` - Displays previous account transactions with extended information.
 
-Once your node is synced, you can start the CPU miner.
-
-`miner start` - Starts the miner. The miner will mine to your currently selected account. (So you need to have a wallet open and an 
-account selected to start the miner)
+Once your node is synced, you can begin mining.
 
 `monitor` - A test screen environment that periodically updates account balances.
 
-`rpc` - Allows you to execute RPC methods against the node (not all methods are currently available)
-
+`rpc` - Allows you to execute RPC methods against the node (note that not all methods are currently available).

--- a/cli/src/modules/import.rs
+++ b/cli/src/modules/import.rs
@@ -40,7 +40,7 @@ impl Import {
                 } else if application_runtime::is_web() {
                     return Err("'karlsen-network' web wallet storage not found at this domain name".into());
                 } else {
-                    return Err("KDX/karlsen-network keydata file not found".into());
+                    return Err("Karlsen-Desktop/karlsen-network keydata file not found".into());
                 }
             }
             // todo "read-only" => {}
@@ -61,7 +61,7 @@ impl Import {
                     "mnemonic [<type>] [<additional xpub keys>] ",
                     "Import a 24 or 12 word mnemonic (types: 'bip32' (default), 'legacy', 'multisig'), ",
                 ),
-                ("legacy", "Import a legacy (local KDX) wallet"),
+                ("legacy", "Import a legacy (local Karlsen-Desktop) wallet"),
                 // ("purge", "Purge an account from the wallet"),
             ],
             None,

--- a/cli/src/modules/wallet.rs
+++ b/cli/src/modules/wallet.rs
@@ -114,7 +114,7 @@ impl Wallet {
                 (
                     "import [<name>]",
                     "Create a wallet from an existing mnemonic (bip32 only). \r\n\r\n\
-                To import legacy wallets (KDX or karlsen-network) please create \
+                To import legacy wallets (Karlsen-Desktop or Web Wallet) please create \
                 a new bip32 wallet and use the 'account import' command. \
                 Legacy wallets can only be imported as accounts. \
                 \r\n",

--- a/wallet/core/src/account/variants/legacy.rs
+++ b/wallet/core/src/account/variants/legacy.rs
@@ -1,5 +1,5 @@
 //!
-//! Legacy (KDX, karlsen-network.io Web Wallet) account implementation
+//! Legacy (Karlsen-Desktop, wallet.karlsencoin.com Web Wallet) account implementation
 //!
 
 use crate::account::{AsLegacyAccount, Inner};
@@ -20,7 +20,7 @@ impl Factory for Ctor {
     }
 
     fn description(&self) -> String {
-        "Karlsen Legacy Account (KDX, karlsen-network.io Web Wallet)".to_string()
+        "Karlsen Legacy Account (Karlsen-Desktop, wallet.karlsencoin.com Web Wallet)".to_string()
     }
 
     async fn try_load(

--- a/wallet/core/src/api/traits.rs
+++ b/wallet/core/src/api/traits.rs
@@ -189,7 +189,7 @@ pub trait WalletApi: Send + Sync + AnySync {
     ///
     /// If `legacy_accounts` is true, the wallet will enable legacy account compatibility mode
     /// allowing the wallet to operate on legacy accounts. Legacy accounts were created by
-    /// applications such as KDX and karlsen-network.io web wallet using a deprecated derivation path
+    /// applications such as Karlsen-Desktop and wallet.karlsencoin.com web wallet using a deprecated derivation path
     /// and are considered deprecated. Legacy accounts should not be used in 3rd-party applications.
     ///
     /// See [`wallet_open`](Self::wallet_open) for a convenience wrapper around this call.

--- a/wallet/core/src/compat/gen0.rs
+++ b/wallet/core/src/compat/gen0.rs
@@ -1,5 +1,5 @@
 //!
-//! v0 (KDX-style) account data decryption
+//! v0 (Karlsen-Desktop-style) account data decryption
 //!
 
 use crate::error::Error;


### PR DESCRIPTION
- Renamed `KDX` (Kaspa Desktop Gui wallet) to [Karlsen Desktop](https://github.com/karlsen-network/karlsen-desktop) (Karlsen Desktop GUI wallet) for correct naming 87f057633a4d6b2432313d2ff8a7c2a9f4c35c89
- Updated `guide.txt` for better clarity 3a99c84e5ef94a8cbcf06bc05fab3a74065cfbc9