### PR TITLE
Testnet karlsenhashv2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ members = [
 
 [workspace.package]
 rust-version = "1.78.0"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Karlsen developers"]
 license = "ISC"
 repository = "https://github.com/karlsen-network/rusty-karlsen"
@@ -79,62 +79,62 @@ include = [
 ]
 
 [workspace.dependencies]
-# karlsen-testing-integration = { version = "2.0.0", path = "testing/integration" }
-karlsen-addresses = { version = "2.0.0", path = "crypto/addresses" }
-karlsen-addressmanager = { version = "2.0.0", path = "components/addressmanager" }
-karlsen-bip32 = { version = "2.0.0", path = "wallet/bip32" }
-karlsen-resolver = { version = "2.0.0", path = "rpr/wrpc/resolver" }
-karlsen-cli = { version = "2.0.0", path = "cli" }
-karlsen-connectionmanager = { version = "2.0.0", path = "components/connectionmanager" }
-karlsen-consensus = { version = "2.0.0", path = "consensus" }
-karlsen-consensus-core = { version = "2.0.0", path = "consensus/core" }
-karlsen-consensus-client = { version = "2.0.0", path = "consensus/client" }
-karlsen-consensus-notify = { version = "2.0.0", path = "consensus/notify" }
-karlsen-consensus-wasm = { version = "2.0.0", path = "consensus/wasm" }
-karlsen-consensusmanager = { version = "2.0.0", path = "components/consensusmanager" }
-karlsen-core = { version = "2.0.0", path = "core" }
-karlsen-daemon = { version = "2.0.0", path = "daemon" }
-karlsen-database = { version = "2.0.0", path = "database" }
-karlsen-grpc-client = { version = "2.0.0", path = "rpc/grpc/client" }
-karlsen-grpc-core = { version = "2.0.0", path = "rpc/grpc/core" }
-karlsen-grpc-server = { version = "2.0.0", path = "rpc/grpc/server" }
-karlsen-hashes = { version = "2.0.0", path = "crypto/hashes" }
-karlsen-index-core = { version = "2.0.0", path = "indexes/core" }
-karlsen-index-processor = { version = "2.0.0", path = "indexes/processor" }
-karlsen-math = { version = "2.0.0", path = "math" }
-karlsen-merkle = { version = "2.0.0", path = "crypto/merkle" }
-karlsen-metrics-core = { version = "2.0.0", path = "metrics/core" }
-karlsen-mining = { version = "2.0.0", path = "mining" }
-karlsen-mining-errors = { version = "2.0.0", path = "mining/errors" }
-karlsen-muhash = { version = "2.0.0", path = "crypto/muhash" }
-karlsen-notify = { version = "2.0.0", path = "notify" }
-karlsen-p2p-flows = { version = "2.0.0", path = "protocol/flows" }
-karlsen-p2p-lib = { version = "2.0.0", path = "protocol/p2p" }
-karlsen-perf-monitor = { version = "2.0.0", path = "metrics/perf_monitor" }
-karlsen-pow = { version = "2.0.0", path = "consensus/pow" }
-karlsen-rpc-core = { version = "2.0.0", path = "rpc/core" }
-karlsen-rpc-macros = { version = "2.0.0", path = "rpc/macros" }
-karlsen-rpc-service = { version = "2.0.0", path = "rpc/service" }
-karlsen-txscript = { version = "2.0.0", path = "crypto/txscript" }
-karlsen-txscript-errors = { version = "2.0.0", path = "crypto/txscript/errors" }
-karlsen-utils = { version = "2.0.0", path = "utils" }
-karlsen-utils-tower = { version = "2.0.0", path = "utils/tower" }
-karlsen-utxoindex = { version = "2.0.0", path = "indexes/utxoindex" }
-karlsen-wallet = { version = "2.0.0", path = "wallet/native" }
-karlsen-wallet-cli-wasm = { version = "2.0.0", path = "wallet/wasm" }
-karlsen-wallet-keys = { version = "2.0.0", path = "wallet/keys" }
-karlsen-wallet-core = { version = "2.0.0", path = "wallet/core" }
-karlsen-wallet-macros = { version = "2.0.0", path = "wallet/macros" }
-karlsen-wasm = { version = "2.0.0", path = "wasm" }
-karlsen-wasm-core = { version = "2.0.0", path = "wasm/core" }
-karlsen-wrpc-client = { version = "2.0.0", path = "rpc/wrpc/client" }
-karlsen-wrpc-core = { version = "2.0.0", path = "rpc/wrpc/core" }
-karlsen-wrpc-proxy = { version = "2.0.0", path = "rpc/wrpc/proxy" }
-karlsen-wrpc-server = { version = "2.0.0", path = "rpc/wrpc/server" }
-karlsen-wrpc-wasm = { version = "2.0.0", path = "rpc/wrpc/wasm" }
-karlsen-wrpc-example-subscriber = { version = "2.0.0", path = "rpc/wrpc/examples/subscriber" }
-karlsend = { version = "2.0.0", path = "karlsend" }
-karlsen-alloc = { version = "2.0.0", path = "utils/alloc" }
+# karlsen-testing-integration = { version = "2.0.1", path = "testing/integration" }
+karlsen-addresses = { version = "2.0.1", path = "crypto/addresses" }
+karlsen-addressmanager = { version = "2.0.1", path = "components/addressmanager" }
+karlsen-bip32 = { version = "2.0.1", path = "wallet/bip32" }
+karlsen-resolver = { version = "2.0.1", path = "rpr/wrpc/resolver" }
+karlsen-cli = { version = "2.0.1", path = "cli" }
+karlsen-connectionmanager = { version = "2.0.1", path = "components/connectionmanager" }
+karlsen-consensus = { version = "2.0.1", path = "consensus" }
+karlsen-consensus-core = { version = "2.0.1", path = "consensus/core" }
+karlsen-consensus-client = { version = "2.0.1", path = "consensus/client" }
+karlsen-consensus-notify = { version = "2.0.1", path = "consensus/notify" }
+karlsen-consensus-wasm = { version = "2.0.1", path = "consensus/wasm" }
+karlsen-consensusmanager = { version = "2.0.1", path = "components/consensusmanager" }
+karlsen-core = { version = "2.0.1", path = "core" }
+karlsen-daemon = { version = "2.0.1", path = "daemon" }
+karlsen-database = { version = "2.0.1", path = "database" }
+karlsen-grpc-client = { version = "2.0.1", path = "rpc/grpc/client" }
+karlsen-grpc-core = { version = "2.0.1", path = "rpc/grpc/core" }
+karlsen-grpc-server = { version = "2.0.1", path = "rpc/grpc/server" }
+karlsen-hashes = { version = "2.0.1", path = "crypto/hashes" }
+karlsen-index-core = { version = "2.0.1", path = "indexes/core" }
+karlsen-index-processor = { version = "2.0.1", path = "indexes/processor" }
+karlsen-math = { version = "2.0.1", path = "math" }
+karlsen-merkle = { version = "2.0.1", path = "crypto/merkle" }
+karlsen-metrics-core = { version = "2.0.1", path = "metrics/core" }
+karlsen-mining = { version = "2.0.1", path = "mining" }
+karlsen-mining-errors = { version = "2.0.1", path = "mining/errors" }
+karlsen-muhash = { version = "2.0.1", path = "crypto/muhash" }
+karlsen-notify = { version = "2.0.1", path = "notify" }
+karlsen-p2p-flows = { version = "2.0.1", path = "protocol/flows" }
+karlsen-p2p-lib = { version = "2.0.1", path = "protocol/p2p" }
+karlsen-perf-monitor = { version = "2.0.1", path = "metrics/perf_monitor" }
+karlsen-pow = { version = "2.0.1", path = "consensus/pow" }
+karlsen-rpc-core = { version = "2.0.1", path = "rpc/core" }
+karlsen-rpc-macros = { version = "2.0.1", path = "rpc/macros" }
+karlsen-rpc-service = { version = "2.0.1", path = "rpc/service" }
+karlsen-txscript = { version = "2.0.1", path = "crypto/txscript" }
+karlsen-txscript-errors = { version = "2.0.1", path = "crypto/txscript/errors" }
+karlsen-utils = { version = "2.0.1", path = "utils" }
+karlsen-utils-tower = { version = "2.0.1", path = "utils/tower" }
+karlsen-utxoindex = { version = "2.0.1", path = "indexes/utxoindex" }
+karlsen-wallet = { version = "2.0.1", path = "wallet/native" }
+karlsen-wallet-cli-wasm = { version = "2.0.1", path = "wallet/wasm" }
+karlsen-wallet-keys = { version = "2.0.1", path = "wallet/keys" }
+karlsen-wallet-core = { version = "2.0.1", path = "wallet/core" }
+karlsen-wallet-macros = { version = "2.0.1", path = "wallet/macros" }
+karlsen-wasm = { version = "2.0.1", path = "wasm" }
+karlsen-wasm-core = { version = "2.0.1", path = "wasm/core" }
+karlsen-wrpc-client = { version = "2.0.1", path = "rpc/wrpc/client" }
+karlsen-wrpc-core = { version = "2.0.1", path = "rpc/wrpc/core" }
+karlsen-wrpc-proxy = { version = "2.0.1", path = "rpc/wrpc/proxy" }
+karlsen-wrpc-server = { version = "2.0.1", path = "rpc/wrpc/server" }
+karlsen-wrpc-wasm = { version = "2.0.1", path = "rpc/wrpc/wasm" }
+karlsen-wrpc-example-subscriber = { version = "2.0.1", path = "rpc/wrpc/examples/subscriber" }
+karlsend = { version = "2.0.1", path = "karlsend" }
+karlsen-alloc = { version = "2.0.1", path = "utils/alloc" }
 
 # external
 aes = "0.8.3"

--- a/consensus/core/src/config/params.rs
+++ b/consensus/core/src/config/params.rs
@@ -413,7 +413,7 @@ pub const TESTNET_PARAMS: Params = Params {
     skip_proof_of_work: false,
     max_block_level: 250,
     pruning_proof_m: 1000,
-    hf_daa_score: 6000000,
+    hf_daa_score: 43200, // HF DAAscore to switch to khashv2 (12 hours after testnet launch)
 };
 
 pub const TESTNET11_PARAMS: Params = Params {


### PR DESCRIPTION
HF DAAscore to switch to `khashv2` (12 hours after testnet launch) a4b63bbf3605c503010450ddf2c5d4cf06d94d50

We've experimented with 3 different hashing algorithm in `testnet`, named `khashv1`, `khashv1.5` and `khashv2`.

```
khashv1   = KarlsenHashv1
khashv1.5 = FishHash
khashv2   = FishHash Plus (KarlsenHashv2)
```

However at the end we've decided to use FishHash Plus as it was result of security review of the FishHash algorithm. The PoW code for FishHash is still there, but the expected blocks are either version 1 or version 2. Therefore we decided to restart testnet-1 with shorter HF DAA score and don't need to maintain code for special case in the network.